### PR TITLE
Cmake integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.20) # TODO: reevaluate min version
+project(tgl LANGUAGES CXX)
+
+add_library(tgl_graphs "${CMAKE_CURRENT_SOURCE_DIR}/graphs.cpp")
+add_library(${PROJECT_NAME}::graphs ALIAS tgl_graphs)
+target_include_directories(tgl_graphs PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_library(tgl_tables "${CMAKE_CURRENT_SOURCE_DIR}/tables.cpp")
+add_library(${PROJECT_NAME}::tables ALIAS tgl_tables)
+target_include_directories(tgl_tables PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,16 @@
-cmake_minimum_required(VERSION 3.20) # TODO: reevaluate min version
-project(tgl LANGUAGES CXX)
+cmake_minimum_required(VERSION 3.19)
+project(tglib LANGUAGES CXX)
 
-add_library(tgl_graphs "${CMAKE_CURRENT_SOURCE_DIR}/graphs.cpp")
-add_library(${PROJECT_NAME}::graphs ALIAS tgl_graphs)
-target_include_directories(tgl_graphs PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+add_library(tglib_graphs INTERFACE)
+add_library(${PROJECT_NAME}::graphs ALIAS tglib_graphs)
+target_sources(tglib_graphs PUBLIC
+    FILE_SET HEADERS
+    BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}
+    FILES graphs.hpp)
 
-add_library(tgl_tables "${CMAKE_CURRENT_SOURCE_DIR}/tables.cpp")
-add_library(${PROJECT_NAME}::tables ALIAS tgl_tables)
-target_include_directories(tgl_tables PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+add_library(tglib_tables INTERFACE)
+add_library(${PROJECT_NAME}::tables ALIAS tglib_tables)
+target_sources(tglib_tables PUBLIC
+    FILE_SET HEADERS
+    BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}
+    FILES tables.hpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,9 @@
-cmake_minimum_required(VERSION 3.19)
+cmake_minimum_required(VERSION 3.21)
 project(tglib LANGUAGES CXX)
 
+# leave compiler options up to parent project, as these libs are header-only
+
+# create header-only interface target for graphs.hpp
 add_library(tglib_graphs INTERFACE)
 add_library(${PROJECT_NAME}::graphs ALIAS tglib_graphs)
 target_sources(tglib_graphs PUBLIC
@@ -8,9 +11,20 @@ target_sources(tglib_graphs PUBLIC
     BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}
     FILES graphs.hpp)
 
+# create header-only interface target for tables.hpp
 add_library(tglib_tables INTERFACE)
 add_library(${PROJECT_NAME}::tables ALIAS tglib_tables)
 target_sources(tglib_tables PUBLIC
     FILE_SET HEADERS
     BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}
     FILES tables.hpp)
+
+# compile example binaries as executables
+if (PROJECT_IS_TOP_LEVEL)
+    set(CMAKE_CXX_STANDARD 14)
+    set(CMAKE_CXX_STANDARD_REQUIRED ON)
+    add_executable(tglib_graphs_example "${CMAKE_CURRENT_SOURCE_DIR}/graphs.cpp")
+    target_link_libraries(tglib_graphs_example PRIVATE tglib::graphs)
+    add_executable(tglib_tables_example "${CMAKE_CURRENT_SOURCE_DIR}/tables.cpp")
+    target_link_libraries(tglib_tables_example PRIVATE tglib::tables)
+endif()

--- a/graphs.hpp
+++ b/graphs.hpp
@@ -1,5 +1,5 @@
 // Teal Dulcet, CS546
-
+#pragma once
 #include <iostream>
 #include <sstream>
 #include <cstring>

--- a/graphs.hpp
+++ b/graphs.hpp
@@ -19,8 +19,13 @@
 #include <sys/ioctl.h>
 #include <unistd.h>
 
+#ifdef TGLIB_GRAPHS_NAMESPACE
+namespace TGLIB_GRAPHS_NAMESPACE
+{
+#else
 namespace graphs
 {
+#endif
 	using namespace std;
 
 	enum style_type

--- a/tables.hpp
+++ b/tables.hpp
@@ -1,5 +1,5 @@
 // Teal Dulcet, CS546
-
+#pragma once
 #include <iostream>
 #include <sstream>
 #include <cstring>

--- a/tables.hpp
+++ b/tables.hpp
@@ -14,8 +14,13 @@
 #include <unistd.h>
 #include <regex>
 
+#ifdef TGLIB_TABLES_NAMESPACE
+namespace TGLIB_TABLES_NAMESPACE
+{
+#else
 namespace tables
 {
+#endif
 	using namespace std;
 
 	enum style_type


### PR DESCRIPTION
Implements issue #3 

The CMakeLists.txt now contains two header-only targets (INTERFACE in CMake):
`tglib::graphs`
and
`tglib::tables`
which can be linked against individually.
If the project is top-level, it also compiles both exampel executables, which could be turned into tests later.

The namespace customization was done using macros at the very top of both **graphs.hpp** and **tables.hpp** using **TGLIB_GRAPHS_NAMESPACE** and **TGLIB_TABLES_NAMESPACE** respectively.

I also added C++-style include guards in the form of **#pragma once** to avoid duplicate symbols.
