### PR TITLE
ODR violation fix via function inlining

### DIFF
--- a/graphs.hpp
+++ b/graphs.hpp
@@ -153,8 +153,6 @@ namespace graphs
 
 	struct options
 	{
-		options() = default;
-		options(type_type type) : type(type) {}
 		bool border = false;
 		bool axis = true;
 		bool axislabel = true;
@@ -776,7 +774,7 @@ namespace graphs
 	}
 
 	template <typename T>
-	int histogram(size_t height, size_t width, long double xmin, long double xmax, long double ymin, long double ymax, const T &aarray, const options &aoptions = {type_histogram})
+	int histogram(size_t height, size_t width, long double xmin, long double xmax, long double ymin, long double ymax, const T &aarray, const options &aoptions = {.type = type_histogram})
 	{
 		if (!graphs::size(aarray))
 			return 1;
@@ -881,7 +879,7 @@ namespace graphs
 	}
 
 	template <typename T>
-	int histogram(size_t height, size_t width, long double xmin, long double xmax, long double ymin, long double ymax, const size_t rows, T *aarray, const options &aoptions = {type_histogram})
+	int histogram(size_t height, size_t width, long double xmin, long double xmax, long double ymin, long double ymax, const size_t rows, T *aarray, const options &aoptions = {.type = type_histogram})
 	{
 		if (rows == 0)
 			return 1;

--- a/graphs.hpp
+++ b/graphs.hpp
@@ -774,7 +774,7 @@ namespace graphs
 	}
 
 	template <typename T>
-	int histogram(size_t height, size_t width, long double xmin, long double xmax, long double ymin, long double ymax, const T &aarray, const options &aoptions = {.type = type_histogram})
+	int histogram(size_t height, size_t width, long double xmin, long double xmax, long double ymin, long double ymax, const T &aarray, const options &aoptions = {})
 	{
 		if (!graphs::size(aarray))
 			return 1;
@@ -879,7 +879,7 @@ namespace graphs
 	}
 
 	template <typename T>
-	int histogram(size_t height, size_t width, long double xmin, long double xmax, long double ymin, long double ymax, const size_t rows, T *aarray, const options &aoptions = {.type = type_histogram})
+	int histogram(size_t height, size_t width, long double xmin, long double xmax, long double ymin, long double ymax, const size_t rows, T *aarray, const options &aoptions = {})
 	{
 		if (rows == 0)
 			return 1;

--- a/graphs.hpp
+++ b/graphs.hpp
@@ -868,13 +868,10 @@ namespace graphs
 		}
 	
 		if (aoptions.type != type_histogram) {
-			options aoptions_hist = aoptions;
-			aoptions_hist.type = type_histogram;
+			options hist_options = aoptions;
+			hist_options.type = type_histogram;
+			return graph(height, width, xmin, xmax, ymin, ymax, aaarray, hist_options);
 		}
-		else {
-			return graph(height, width, xmin, xmax, ymin, ymax, aaarray, aoptions);
-		}
-
 		return graph(height, width, xmin, xmax, ymin, ymax, aaarray, aoptions);
 	}
 

--- a/tables.hpp
+++ b/tables.hpp
@@ -65,8 +65,6 @@ namespace tables
 		bool check = true;
 	};
 
-	const options defaultoptions;
-
 	template <typename T>
 	constexpr size_t size(const T &array)
 	{
@@ -75,7 +73,7 @@ namespace tables
 
 	// Number of columns needed to represent the string
 	// Adapted from: https://stackoverflow.com/a/31124065
-	int strcol(const char *str)
+	inline int strcol(const char *str)
 	{
 		const string astr = regex_replace(str, ansi, "");
 		str = astr.c_str();
@@ -123,7 +121,7 @@ namespace tables
 	// Word wrap
 	// Source: https://gist.github.com/tdulcet/819821ca69501822ad3f84a060c640a0
 	// Adapted from: https://stackoverflow.com/a/42016346 and https://stackoverflow.com/a/13094734
-	string wrap(const char *const str, const size_t line_length)
+	inline string wrap(const char *const str, const size_t line_length)
 	{
 		string words = str;
 		string wrapped;
@@ -352,7 +350,7 @@ namespace tables
 
 	// Convert array to char array and output as table
 	template <typename T1, typename T2>
-	int array(const T1 &aarray, T2 headerrow[] = nullptr, T2 headercolumn[] = nullptr, const options &aoptions = defaultoptions)
+	int array(const T1 &aarray, T2 headerrow[] = nullptr, T2 headercolumn[] = nullptr, const options &aoptions = {})
 	{
 		if (!tables::size(aarray))
 			return 1;
@@ -423,7 +421,7 @@ namespace tables
 	}
 
 	template <typename T>
-	int array(const size_t rows, const size_t columns, T **aarray, const char *const headerrow[] = nullptr, const char *const headercolumn[] = nullptr, const options &aoptions = defaultoptions)
+	int array(const size_t rows, const size_t columns, T **aarray, const char *const headerrow[] = nullptr, const char *const headercolumn[] = nullptr, const options &aoptions = {})
 	{
 		vector<vector<T>> aaarray(rows, vector<T>(columns));
 		for (size_t i = 0; i < rows; ++i)
@@ -460,7 +458,7 @@ namespace tables
 
 	// Convert one or more functions to array and output as table
 	template <typename T>
-	int functions(const long double xmin, const long double xmax, const long double xstep, const size_t numfunctions, function<T(T)> functions[], const options &aoptions = defaultoptions)
+	int functions(const long double xmin, const long double xmax, const long double xstep, const size_t numfunctions, function<T(T)> functions[], const options &aoptions = {})
 	{
 		if (numfunctions == 0)
 			return 1;
@@ -538,7 +536,7 @@ namespace tables
 
 	// Convert single function to array and output as table
 	template <typename T>
-	int function(const long double xmin, const long double xmax, const long double xstep, const function<T(T)> &afunction, const options &aoptions = defaultoptions)
+	int function(const long double xmin, const long double xmax, const long double xstep, const function<T(T)> &afunction, const options &aoptions = {})
 	{
 		std::function<T(T)> afunctions[] = {afunction};
 
@@ -547,7 +545,7 @@ namespace tables
 
 	// Convert single function to array and output as table
 	template <typename T>
-	int function(const long double xmin, const long double xmax, const long double xstep, T afunction(T), const options &aoptions = defaultoptions)
+	int function(const long double xmin, const long double xmax, const long double xstep, T afunction(T), const options &aoptions = {})
 	{
 		std::function<T(T)> afunctions[] = {afunction};
 


### PR DESCRIPTION
Being a header-only library, a lot of the functions are floating around inside the headers without being explicitly marked inline or static. This might lead to the violation of the [ODR](https://en.cppreference.com/w/cpp/language/definition), depending on whether the compiler decides to inline the function or not. Templated functions are always inlined, so those do not require an extra specifier.

I've marked the affected functions as **inline**, rather than **static**, as it makes the most sense for a header-only library like this. 

The **defaultoptions** and its counterpart for histograms would also violate the ODR, but do not really need to exist in global space at all. I have constructed them as default args, which would still allow in-place construction due to **const param&**. Since you explicitly edit the default param to contain the histogram type, I simply create a copy and pass that off to the graphs() function. A better solution might some sort of overload, especially since it would allow the options struct to not need a specialized constructor (really nice for [aggregate initialization](https://en.cppreference.com/w/cpp/language/aggregate_initialization).

If you want to keep some sort of global default option object, another solution might be to create **static constexpr** versions of them.